### PR TITLE
Fixed initialRouteName issue.

### DIFF
--- a/Navs/DrawerNav.js
+++ b/Navs/DrawerNav.js
@@ -7,8 +7,14 @@ import FriendManager from "../Screens/FriendManager";
 const DrawerNav = DrawerNavigator(
   {
     homeScreen: { screen: Home },
-    friendManagerScreen: { screen: FriendManager },
+    friendManagerScreen: { screen: FriendManager }
   },
+  {
+    drawerOpenRoute: "DrawerOpen",
+    drawerCloseRoute: "DrawerClose",
+    drawerToggleRoute: "DrawerToggle",
+    initialRouteName: "friendManagerScreen"
+  }
 );
 
 export default DrawerNav;


### PR DESCRIPTION
Wadup! Was doing some research and it turns out that there is a bug with the new version of DrawerNavigator and some settings don't have a default yet. To fix it you must set them by yourself, after you set those settings the initialRouteName works again. See  https://github.com/react-community/react-navigation/issues/3148#issuecomment-352778884